### PR TITLE
feat: github action on pr to main only

### DIFF
--- a/.github/workflows/github-actions-web-manager.yml
+++ b/.github/workflows/github-actions-web-manager.yml
@@ -1,6 +1,9 @@
 name: GitHub Actions Tests
 run-name: ${{ github.actor }}
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
 jobs:
   Web-Manager-Tests:
     name: Web Manager tests


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to trigger tests on pull requests targeting the `main` branch, rather than only on pushes.

* [`.github/workflows/github-actions-web-manager.yml`](diffhunk://#diff-e327f3c62f2b21cda3db259dc6eb370f328e7b05f4da3f3073365bd4c8923d43L3-R6): Modified the `on` trigger to include `pull_request` events for the `main` branch, ensuring tests run automatically for pull requests.