### PR TITLE
fix: job sanitizer

### DIFF
--- a/web-manager/src/backend/models/JobSanitizer.ts
+++ b/web-manager/src/backend/models/JobSanitizer.ts
@@ -331,6 +331,24 @@ export class JobSanitizer {
         : undefined;
     }
 
+    if (input.motivation_email_subject !== undefined) {
+      output.motivation_email_subject = input.motivation_email_subject
+        ? this.sanitizeString(input.motivation_email_subject)
+        : null;
+    }
+
+    if (input.motivation_email_draft_url !== undefined) {
+      output.motivation_email_draft_url = input.motivation_email_draft_url
+        ? this.sanitizeString(input.motivation_email_draft_url)
+        : null;
+    }
+
+    if (input.motivation_email_to !== undefined) {
+      output.motivation_email_to = input.motivation_email_to
+        ? this.sanitizeString(input.motivation_email_to)
+        : null;
+    }
+
     return output;
   }
 
@@ -358,6 +376,9 @@ export class JobSanitizer {
       methodologies: output.methodologies || null,
       motivation_letter: output.motivation_letter || null,
       motivation_email: output.motivation_email || null,
+      motivation_email_draft_url: output.motivation_email_draft_url || null,
+      motivation_email_subject: output.motivation_email_subject || null,
+      motivation_email_to: output.motivation_email_to || null,
       original_job_id: output.original_job_id || null,
       preference: output.preference || null,
       salary: output.salary || null,


### PR DESCRIPTION
This pull request updates the `JobSanitizer` class in `web-manager/src/backend/models/JobSanitizer.ts` to handle additional fields related to motivation emails. The changes ensure proper sanitization and inclusion of these new fields in the output.

### Enhancements to `JobSanitizer`:

* Added sanitization logic for three new fields: `motivation_email_subject`, `motivation_email_draft_url`, and `motivation_email_to`. These fields are sanitized using `sanitizeString` if they are defined, or set to `null` otherwise.
* Updated the output object to include the new fields (`motivation_email_subject`, `motivation_email_draft_url`, and `motivation_email_to`), defaulting to `null` if not present.