### PR TITLE
fix: docker environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     ports:
       - "3000:3000"
     environment: 
-      - MONGODB_URI=mongodb://${MONGO_DB_NAME}:${MONGO_DB_PASSWORD}@mongodb:27017/${MONGO_DB_NAME}
+      - MONGODB_URI=mongodb://${MONGO_DB_USER}:${MONGO_DB_USER_PASSWORD}@mongodb:27017/${MONGO_DB_NAME}
     depends_on:
       - mongodb
       - vector_proxy


### PR DESCRIPTION
This pull request updates the MongoDB connection configuration in the `docker-compose.yml` file to use the correct environment variables for the database user and password.

Configuration update:

* Updated the `MONGODB_URI` environment variable for the main service to use `MONGO_DB_USER` and `MONGO_DB_USER_PASSWORD` instead of `MONGO_DB_NAME` and `MONGO_DB_PASSWORD` for authentication. (`docker-compose.yml`)